### PR TITLE
Workaround arch-chroot issue #55

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-mnt_image='mnt_image'
+mnt_image="$(pwd)/mnt_image"
 mkosi_output='mkosi.output'
 disk_raw="$mkosi_output/fedora.raw"
 


### PR DESCRIPTION
Networking is broken inside a chroot entered via `./build.sh chroot`. This is none other than [arch-chroot's bug #55](https://gitlab.archlinux.org/archlinux/arch-install-scripts/-/issues/55). More specifically, it is caused by [this line](https://gitlab.archlinux.org/archlinux/arch-install-scripts/-/blob/v28/arch-chroot.in?ref_type=tags#L41) (`$target != $root*`) being unaware of the difference between relative paths (`$root`, the argument of arch-chroot) and absolute paths (`$target`, computed using `readlink` on [this line](https://gitlab.archlinux.org/archlinux/arch-install-scripts/-/blob/v28/arch-chroot.in?ref_type=tags#L38)).

While the next release of arch-chroot will fix bug #55 with an all-new logic, at this moment the issue can be worked around by simply passing an absolute rather than relative path to arch-chroot. The `chroot.asahi` script is fine as it uses `/mnt` as the argument of arch-chroot.