### PR TITLE
Add flag to compress qcow2 image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -133,7 +133,7 @@ make_image() {
     echo "### Converting $mkosi_output/fedora.raw to qemu/fedora.qcow2"
     echo '### To test out the image run:'
     echo 'cd qemu && ./script-qemu.sh'
-    [[ -f $mkosi_output/fedora.raw ]] && qemu-img convert -f raw -O qcow2 $mkosi_output/fedora.raw qemu/fedora.qcow2
+    [[ -f $mkosi_output/fedora.raw ]] && qemu-img convert -f raw -O qcow2 -c $mkosi_output/fedora.raw qemu/fedora.qcow2
 
     echo '### Done'
 }


### PR DESCRIPTION
fedora.qcow2 is currently 1GB large. Compressing it at creation halves its size to 500MB (the same goes for the resulting Vagrant box, of course). Compression takes approx. 1m30s on an M1 Pro MacBookPro (vs. less than 1s with no compression). I believe this is acceptable, given that fedora.qcow2 is created at the end of a process that already takes minutes to complete.