### PR TITLE
Reset selinux status after exit

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -161,6 +161,10 @@ make_image() {
     echo -e '\n### Done'
 }
 
-[[ $(command -v getenforce) ]] && setenforce 0
+if [[ $(command -v getenforce) ]] && [[ "$(getenforce)" = "Enforcing" ]]; then
+    setenforce 0
+    trap 'setenforce 1; exit;' EXIT SIGHUP SIGINT SIGTERM SIGQUIT SIGABRT
+fi
+
 mkosi_create_rootfs
 make_image


### PR DESCRIPTION
This patch resets selinux's status to where it was before the image building process started.