### PR TITLE
Mount btrfs home subvolume

### DIFF
--- a/mkosi.skeleton/usr/local/sbin/chroot.asahi
+++ b/mkosi.skeleton/usr/local/sbin/chroot.asahi
@@ -3,9 +3,9 @@
 systemctl daemon-reload
 root_fs=$(blkid -s TYPE -o value /dev/vdd)
 
-[[ $root_fs == "btrfs" ]] && options='-o subvol=root'
-[[ -z "$(findmnt -n /mnt)" ]] && mount /dev/vdd $options /mnt
-[[ $root_fs == "btrfs" ]] && [[ -z "$(findmnt -n /mnt/home)" ]] && mount /dev/vdd -o subvol=home /mnt/home
+[[ $root_fs == "btrfs" ]] && root_options='-o subvol=root' && home_options='-o subvol=home'
+[[ -z "$(findmnt -n /mnt)" ]] && mount /dev/vdd $root_options /mnt
+[[ -n $home_options ]] && [[ -z "$(findmnt -n /mnt/home)" ]] && mount /dev/vdd $home_options /mnt/home
 [[ -z "$(findmnt -n /mnt/boot)" ]] && mount /dev/vdc /mnt/boot
 [[ -z "$(findmnt -n /mnt/boot/efi)" ]] && mount /dev/vdb /mnt/boot/efi
 

--- a/mkosi.skeleton/usr/local/sbin/chroot.asahi
+++ b/mkosi.skeleton/usr/local/sbin/chroot.asahi
@@ -5,6 +5,7 @@ root_fs=$(blkid -s TYPE -o value /dev/vdd)
 
 [[ $root_fs == "btrfs" ]] && options='-o subvol=root'
 [[ -z "$(findmnt -n /mnt)" ]] && mount /dev/vdd $options /mnt
+[[ $root_fs == "btrfs" ]] && [[ -z "$(findmnt -n /mnt/home)" ]] && mount /dev/vdd -o subvol=home /mnt/home
 [[ -z "$(findmnt -n /mnt/boot)" ]] && mount /dev/vdc /mnt/boot
 [[ -z "$(findmnt -n /mnt/boot/efi)" ]] && mount /dev/vdb /mnt/boot/efi
 

--- a/mkosi.skeleton/usr/local/sbin/umount.asahi
+++ b/mkosi.skeleton/usr/local/sbin/umount.asahi
@@ -2,4 +2,5 @@
 
 [[ "$(findmnt -n /mnt/boot/efi)" ]] && umount /mnt/boot/efi
 [[ "$(findmnt -n /mnt/boot)" ]] && umount /mnt/boot
+[[ "$(findmnt -n /mnt/home)" ]] && umount /mnt/home
 [[ "$(findmnt -n /mnt)" ]] && umount /mnt


### PR DESCRIPTION
To fully mount the root partition, its "home" subvolume must be mounted as well (under /home of course). This patch does that.

While this is probably unnecessary for system recovery & similar operations, it is still nice not to have to separately mount the subvolume e.g. for transfering user files from Fedora Asahi to macOS.